### PR TITLE
shorter default path to archive

### DIFF
--- a/move2archive/__init__.py
+++ b/move2archive/__init__.py
@@ -24,7 +24,7 @@ import readline  # for raw_input() reading from stdin
 DATESTAMP_REGEX = re.compile("\d\d\d\d-[01]\d-[0123]\d")
 
 # this setting is highly specific for the current user and most probably needs adaptation:
-DEFAULT_ARCHIVE_PATH = os.path.join(os.path.expanduser("~"), "archive", "events_memories")
+DEFAULT_ARCHIVE_PATH = os.path.join(os.path.expanduser("~"), "archive")
 
 PAUSEONEXITTEXT = "    press <Enter> to quit"
 PROG_VERSION_DATE = PROG_VERSION[13:23]


### PR DESCRIPTION
By default, earlier commits of m2a assumed the eventual deposit of
files in

~/archive/events_memories

i.e. with ~/archive containing only one folder, events_memories.

Though m2a allows to adjust this by --archivepath, the direct move
into ~/archive (without the extra level of hierarchy) appears just
as functional and more compact.