### PR TITLE
create a new year folder if this wasn't yet in the archive

### DIFF
--- a/move2archive/__init__.py
+++ b/move2archive/__init__.py
@@ -399,7 +399,8 @@ def get_potential_target_directories(args, archivepath):
         try:
             os.mkdir(new_year)
         except IOError:
-            print('Error in set up a folder about new year "%s".' % new_year)
+            print('The creation of new folder "%s" failed.' % new_year)
+            sys.exit()
 
     # existing yearfolder found; looking for matching subfolders:
     logging.debug("looking for potential existing target folders for file \"%s\" in folder \"%s\"" % (firstfile, yearfolder))

--- a/move2archive/__init__.py
+++ b/move2archive/__init__.py
@@ -395,7 +395,11 @@ def get_potential_target_directories(args, archivepath):
     item_date = extract_date(firstfile)
     yearfolder = os.path.join(archivepath, str(item_date.year))
     if not os.path.exists(yearfolder):
-        error_exit(12, 'Folder for year "%s" does not exist! Aborting.' % str(yearfolder))
+        new_year = str(os.path.join(archivepath, yearfolder))
+        try:
+            os.mkdir(new_year)
+        except IOError:
+            print('Error in set up a folder about new year "%s".' % new_year)
 
     # existing yearfolder found; looking for matching subfolders:
     logging.debug("looking for potential existing target folders for file \"%s\" in folder \"%s\"" % (firstfile, yearfolder))


### PR DESCRIPTION
In previous commits, each year of the archive had to be defined
once by the user, or move2archive did not process the file to
archive.  By the present commit, move2archive attempts the set up
the yearly archive on the fly.  In the same run, the file to store
can be moved into this directory, too.
